### PR TITLE
fix logging failed jobs

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -100,11 +100,11 @@ class Worker
     redis.incr "resque:stat:#{key}"
     redis.incr "resque:stat:#{key}:#{name}"
     redis.del "resque:worker:#{name}"
-    redis.quit()
 
   success: ->
     with_redis (redis) =>
       @done(redis, true)
+      redis.quit()
 
   fail: (job, response) ->
     with_redis (redis) =>


### PR DESCRIPTION
`@done()` calls `redis.quit()`, preventing further writes to redis in
`fail()`.

The `redis.lpush()` at
https://github.com/brainlock/resque-runner/blob/d4c7792a744593a94754a55c87c6eba7e975e6e8/lib/runner.coffee#L128
just fails silently :-\
